### PR TITLE
IM-2925: Added support for translation strings

### DIFF
--- a/_conf/strings-en.tpl
+++ b/_conf/strings-en.tpl
@@ -1,0 +1,4 @@
+### en language template strings for Storyteller v1 ### 
+
+# global strings
+open = "Open"

--- a/_conf/strings-es.tpl
+++ b/_conf/strings-es.tpl
@@ -1,0 +1,4 @@
+### en language template strings for Storyteller v1 ### 
+
+# global strings
+open = "Entrar"

--- a/_conf/strings-fr.tpl
+++ b/_conf/strings-fr.tpl
@@ -1,0 +1,4 @@
+### en language template strings for Storyteller v1 ### 
+
+# global strings
+open = "Entrer"

--- a/section.tpl
+++ b/section.tpl
@@ -1,3 +1,6 @@
+{{ $lang = $gimme->issue->language->code }}
+{{ config_load file="strings-{{ $lang }}.tpl" }}
+
 {{ include file="_tpl/_html-head.tpl" }}
 <body class="longform"{{ if $gimme->browser->ua_type == "mobile" }} mobile{{ /if }}>
 <article>
@@ -29,7 +32,7 @@
                   <h1>{{$gimme->article->name}}</h1>
 
 
-                  <a href="{{url options="article"}}" class="startButton" >open</a>
+                  <a href="{{url options="article"}}" class="startButton" >{{ #open# }}</a>
 
               </div>
           </div>


### PR DESCRIPTION
Added support for translation strings on section page. Will need expansing as and when we find use cases.